### PR TITLE
Add task reload call that made statistics service not update correctly

### DIFF
--- a/clearml_serving/serving/model_request_processor.py
+++ b/clearml_serving/serving/model_request_processor.py
@@ -428,6 +428,8 @@ class ModelRequestProcessor(object):
         """
         if not task:
             task = self._task
+
+        task.reload()
         configuration = task.get_parameters_as_dict().get("General") or {}
         endpoints = task.get_configuration_object_as_dict(name='endpoints') or {}
         canary_ep = task.get_configuration_object_as_dict(name='canary') or {}


### PR DESCRIPTION
Task reload was not called on deserialize, which lead to the task not being updated correctly. When updating the configuration on the main control plane service, the inference service would correctly sync, but the statistics service wouldn't.