### PR TITLE
Fix bug where custom buckets are not passed through correctly

### DIFF
--- a/clearml_serving/statistics/metrics.py
+++ b/clearml_serving/statistics/metrics.py
@@ -323,7 +323,7 @@ class StatisticsController(object):
         metric_cls = self._metric_type_class.get(metric_.type)
         if not metric_cls:
             return None
-        if metric_cls in (Histogram, EnumHistogram):
+        if metric_cls in (ScalarHistogram, EnumHistogram):
             return metric_cls(
                 name=name,
                 documentation="User defined metric {}".format(metric_.type),


### PR DESCRIPTION
A small typo that lead to the buckets being default instead of user-defined