### PR TITLE
Remove never-used but now deprecated np.int

### DIFF
--- a/clearml_serving/serving/preprocess_service.py
+++ b/clearml_serving/serving/preprocess_service.py
@@ -250,7 +250,6 @@ class TritonPreprocessRequest(BasePreprocessRequest):
         np.int8: 'int_contents',
         np.int64: 'int64_contents',
         np.uint64: 'uint64_contents',
-        np.int: 'int_contents',
         np.int32: 'int_contents',
         np.uint: 'uint_contents',
         np.bool: 'bool_contents',


### PR DESCRIPTION
Adresses Issue #41 

`np.int` was used [here](https://github.com/allegroai/clearml-serving/blob/e09e6362147da84e042b3c615f167882a58b8ac7/clearml_serving/serving/preprocess_service.py#L253) as a lookup table.

But the values that are looked up come from [here](https://github.com/allegroai/clearml-serving/blob/e09e6362147da84e042b3c615f167882a58b8ac7/clearml_serving/serving/preprocess_service.py#L357).
`np.dtype(...)` will never return `np.int` as a value. I tested 1.20 to latest and in every case `np.dtype("int")` returns `np.int64`, so I don't think we ever even have to look up `np.int`. Which means we can safely remove it and fix the bug.