### PR TITLE
changed np.bool deprecated in numpy 1.20.0, changed to bool

### DIFF
--- a/clearml_serving/serving/preprocess_service.py
+++ b/clearml_serving/serving/preprocess_service.py
@@ -252,7 +252,7 @@ class TritonPreprocessRequest(BasePreprocessRequest):
         np.uint64: 'uint64_contents',
         np.int32: 'int_contents',
         np.uint: 'uint_contents',
-        np.bool: 'bool_contents',
+        bool: 'bool_contents',
         np.float32: 'fp32_contents',
         np.float64: 'fp64_contents',
     }


### PR DESCRIPTION
Related to this commit a04d1bd. 

`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
