### PR TITLE
Removes unnessary flatten

### DIFF
--- a/examples/keras/preprocess.py
+++ b/examples/keras/preprocess.py
@@ -31,7 +31,7 @@ class Preprocess(object):
             image = Image.open(local_file)
     
         image = ImageOps.grayscale(image).resize((28, 28))
-        return np.array([np.array(image).flatten()])
+        return np.array([np.array(image)])
 
     def postprocess(self, data: Any, state: dict, collect_custom_statistics_fn=None) -> dict:
         # post process the data returned from the model inference engine

--- a/examples/pytorch/preprocess.py
+++ b/examples/pytorch/preprocess.py
@@ -31,7 +31,7 @@ class Preprocess(object):
             image = Image.open(local_file)
     
         image = ImageOps.grayscale(image).resize((28, 28))
-        return np.array([np.array(image).flatten()])
+        return np.array([np.array(image)])
 
     def postprocess(self, data: Any, state: dict, collect_custom_statistics_fn=None) -> dict:
         # post process the data returned from the model inference engine


### PR DESCRIPTION
This PR fixes https://github.com/allegroai/clearml-serving/issues/48 by removing the unnessary `flatten()` that was causing the following error in `examples/pytorch` and `examples/keras`:

```
{"detail":"Error processing request: <AioRpcError of RPC that terminated with:\n\tstatus = StatusCode.INVALID_ARGUMENT\n\tdetails = \"unexpected shape for input 'INPUT__0' for model 'test_model_pytorch'. Expected [1,28,28], got [1,784]\"\n\tdebug_error_string = \"{\"created\":\"@1680665060.017267956\",\"description\":\"Error received from peer ipv4:172.23.0.5:8001\"
```

This simply makes the input adhere to the shape defined in the tutorial, and one that the model also accepts. 