### PR TITLE
Fix incorrect requests version specifier in requirements.txt 

### DIFF
--- a/clearml_serving/serving/requirements.txt
+++ b/clearml_serving/serving/requirements.txt
@@ -14,6 +14,6 @@ grpcio
 Pillow>=10.0.1
 xgboost>=1.7.5,<1.8
 lightgbm>=3.3.2,<3.4
-requests>=2.31.0,<2.29
+requests>=2.31.0,<2.32.0
 kafka-python>=2.0.2,<2.1
 lz4>=4.0.0,<5


### PR DESCRIPTION
ref: [#66 ](https://github.com/allegroai/clearml-serving/issues/66)
fix request lib from >=2.31.0,<2.29.0 to >=2.31.0,<2.32.0