### PR TITLE
added exit-on-error option for tritonserver. 

### DIFF
--- a/clearml_serving/engines/triton/triton_helper.py
+++ b/clearml_serving/engines/triton/triton_helper.py
@@ -540,6 +540,12 @@ def main():
     parser.add_argument(
         '--t-log-verbose', type=str,
         help='<integer> Triton server logging verbosity (default disabled)')
+    parser.add_argument(
+        '--t-exit-on-error', type=bool, default=True,
+        help='Exits the inference server if any error occurs during initialization.'
+             'Recommended to set to True to catch any unanticipated errors.'
+             'False prevents single models breaking the whole tritonserver.'
+    )
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Add the option to send exit-on-error parameter to tritonserver. Setting this to false prevents single models breaking a whole tritonserver instance.

Fixes allegroai/clearml-serving#60